### PR TITLE
Update typo in 02.html

### DIFF
--- a/html/02.html
+++ b/html/02.html
@@ -46,7 +46,7 @@ Note: Legacy Rust code (before 0.9) also has a "managed pointer" represented by 
 In Rust, there is a notion of <em>ownership</em> of an object.  The owner of an
 object, which could be a variable that refers to that object, manages
 the object's lifetime (that is, when its memory is allocated and
-reclaimed).  Programmers do not have to explicitly allocated and
+reclaimed).  Programmers do not have to explicitly allocate and
 deallocate storage.  Rather, it is done by the Rust compiler and runtime
 based on how the object references are used.
 </p>


### PR DESCRIPTION
Found a typo - should read as “… Programmers do not have to explicitly allocate” and not “… Programmers do not have to explicitly allocated”